### PR TITLE
fix: resolve Python 3.11+ f-string SyntaxError in offload_bash.py

### DIFF
--- a/plugins/fewword/hooks/scripts/offload_bash.py
+++ b/plugins/fewword/hooks/scripts/offload_bash.py
@@ -289,6 +289,9 @@ def generate_wrapper(original_cmd: str, output_dir: str, safe_cmd: str,
     escaped_session = session_id.replace("'", "'\"'\"'")
     escaped_cmd_token = cmd_token.replace("'", "'\"'\"'")
     escaped_cmd_group = cmd_group.replace("'", "'\"'\"'")
+    # Pre-compute expressions to avoid f-string compatibility issues (Python 3.11+)
+    denied_str = 'true' if denied else 'false'
+    escaped_deny_reason = deny_reason.replace("'", "'\"'\"'") if deny_reason else ""
 
     wrapper = f'''
 set -o pipefail
@@ -303,8 +306,8 @@ __fw_open_cmd='{escaped_open_cmd}'
 __fw_cmd_token='{escaped_cmd_token}'
 __fw_cmd_group='{escaped_cmd_group}'
 __fw_manifest="$__fw_cwd/.fewword/index/tool_outputs.jsonl"
-__fw_denied={'true' if denied else 'false'}
-__fw_deny_reason='{deny_reason.replace("'", "'\"'\"'") if deny_reason else ""}'
+__fw_denied={denied_str}
+__fw_deny_reason='{escaped_deny_reason}'
 
 # P1 fix #13: Robust JSON escape helper
 # Uses jq -Rs if available (proper JSON escaping), falls back to sed-based escaping


### PR DESCRIPTION
## Problem

The `offload_bash.py` hook fails with a `SyntaxError` on Python 3.11+:

```
SyntaxError: f-string expression part cannot include a backslash
```

This causes the FewWord plugin to be completely non-functional - no outputs are offloaded.

## Root Cause

The f-string in `generate_wrapper()` (line 293) contains complex expressions:

```python
__fw_denied={'true' if denied else 'false'}
__fw_deny_reason='{deny_reason.replace("'", "'\"'\"'") if deny_reason else ""}'
```

Combined with shell script content containing backslashes (lines 317-319), this confuses Python's f-string parser in versions 3.11+.

## Solution

Pre-compute the problematic expressions before the f-string:

```python
denied_str = 'true' if denied else 'false'
escaped_deny_reason = deny_reason.replace("'", "'\"'\"'") if deny_reason else ""
```

Then use simple variable substitution:

```python
__fw_denied={denied_str}
__fw_deny_reason='{escaped_deny_reason}'
```

## Testing

- Verified syntax with `ast.parse()` on Python 3.11.5
- Tested hook execution with simulated input - produces valid JSON output
- Tested real bash commands - offloading works correctly (97% token reduction observed)

## Environment

- Python 3.11.5
- macOS Darwin 25.1.0
- Claude Code CLI